### PR TITLE
Make tests independent of config.ini contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 mlruns/
 
 # Byte-compiled / optimized / DLL files

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,4 +10,3 @@ def empty_config_path(tmp_path_factory):
     config_path.touch()
 
     return config_path
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Configuration of tests."""
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def empty_config_path(tmp_path_factory):
+    """Create an empty config.ini file."""
+    config_path = tmp_path_factory.getbasetemp() / "config.ini"
+    config_path.touch()
+
+    return config_path
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ import pytest
 import mltype.cli
 
 
-def command_composer(args, options, use_long=True):
+def command_composer(args, options, use_long=True, config_path=None):
     """Compose arguments and options.
 
     Parameters
@@ -22,6 +22,9 @@ def command_composer(args, options, use_long=True):
             * short_option  # str
             * long_option  # str
             * value  # str or bool
+
+    config_path : None or Path
+        If specified, then it represents the path to the config file.
     """
     s = " ".join(args) + " "
 
@@ -36,6 +39,9 @@ def command_composer(args, options, use_long=True):
         elements.append(f"{dash}{name}{value}")
 
     s += " ".join(elements)
+
+    if config_path is not None:
+        s += f" --config {config_path}"
 
     return s
 
@@ -63,6 +69,7 @@ def test_help(cmd):
 @pytest.mark.parametrize("use_long", [True, False])
 @pytest.mark.parametrize("target_wpm", [55])
 def test_file(
+    empty_config_path,
     tmpdir,
     monkeypatch,
     end_line,
@@ -97,7 +104,10 @@ def test_file(
         ("w", "include-whitespace", include_whitespace),
     ]
 
-    command = command_composer((str(file_path),), options, use_long=use_long)
+    command = command_composer((str(file_path),),
+                               options,
+                               use_long=use_long,
+                               config_path=empty_config_path)
     print(command)  # to know why it failed
 
     result = runner.invoke(file_, command)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,10 +104,12 @@ def test_file(
         ("w", "include-whitespace", include_whitespace),
     ]
 
-    command = command_composer((str(file_path),),
-                               options,
-                               use_long=use_long,
-                               config_path=empty_config_path)
+    command = command_composer(
+        (str(file_path),),
+        options,
+        use_long=use_long,
+        config_path=empty_config_path,
+    )
     print(command)  # to know why it failed
 
     result = runner.invoke(file_, command)
@@ -201,6 +203,7 @@ def test_ls(tmpdir, monkeypatch, dir_exists, from_config):
 @pytest.mark.parametrize("use_long", [True, False])
 @pytest.mark.parametrize("target_wpm", [55])
 def test_random(
+    empty_config_path,
     monkeypatch,
     force_perfect,
     instant_death,
@@ -223,7 +226,9 @@ def test_random(
         ("t", "target-wpm", target_wpm),
     ]
 
-    command = command_composer(("abc",), options, use_long=use_long)
+    command = command_composer(
+        ("abc",), options, use_long=use_long, config_path=empty_config_path
+    )
     print(command)  # to know why it failed
 
     result = runner.invoke(random, command)
@@ -250,6 +255,7 @@ def test_random(
 @pytest.mark.parametrize("use_long", [True, False])
 @pytest.mark.parametrize("target_wpm", [33])
 def test_raw(
+    empty_config_path,
     monkeypatch,
     force_perfect,
     instant_death,
@@ -272,7 +278,9 @@ def test_raw(
         ("t", "target-wpm", target_wpm),
     ]
 
-    command = command_composer(("Hello",), options, use_long=use_long)
+    command = command_composer(
+        ("Hello",), options, use_long=use_long, config_path=empty_config_path
+    )
     print(command)  # to know why it failed
 
     result = runner.invoke(raw, command)
@@ -297,6 +305,7 @@ def test_raw(
 @pytest.mark.parametrize("use_long", [True, False])
 @pytest.mark.parametrize("target_wpm", [55])
 def test_replay(
+    empty_config_path,
     monkeypatch,
     force_perfect,
     instant_death,
@@ -317,7 +326,9 @@ def test_replay(
         ("t", "target-wpm", target_wpm),
     ]
 
-    command = command_composer(("aa",), options, use_long=use_long)
+    command = command_composer(
+        ("aa",), options, use_long=use_long, config_path=empty_config_path
+    )
     print(command)  # to know why it failed
 
     result = runner.invoke(replay, command)
@@ -451,6 +462,7 @@ def test_sample(
 @pytest.mark.parametrize("vocab_size", [5])
 @pytest.mark.parametrize("window_size", [1])
 def test_train(
+    empty_config_path,
     tmpdir,
     monkeypatch,
     batch_size,
@@ -501,7 +513,10 @@ def test_train(
     ]
 
     command = command_composer(
-        (str(path_dir), str(path_file), "naame"), options, use_long=use_long
+        (str(path_dir), str(path_file), "naame"),
+        options,
+        use_long=use_long,
+        config_path=empty_config_path,
     )
 
     print(command)  # to know why it failed

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -126,8 +126,9 @@ def test_strip(monkeypatch):
 
 @pytest.mark.skipif(isinstance(hecate, Mock), reason="Hecate is not installed")
 class TestHecate:
-    def test_basic(self):
-        with CustomRunner("mlt", "raw", "inside") as r:
+    def test_basic(self, empty_config_path):
+        config_option = f"--config={empty_config_path}"
+        with CustomRunner("mlt", "raw", "inside", config_option) as r:
             to = 2
             assert r.get_cursor_position() == (0, 0)
             # initial check
@@ -167,8 +168,9 @@ class TestHecate:
 
             r.await_ctext("== Statistics ==")
 
-    def test_target_speed(self):
-        with CustomRunner("mlt", "raw", "hello", "-t", "120") as r:
+    def test_target_speed(self, empty_config_path):
+        config_opt = f"--config={empty_config_path}"
+        with CustomRunner("mlt", "raw", "hello", "-t", "120", config_opt) as r:
             to = 2
             r.await_ctext(gen_fb("white", DEFAULT_BACKGROUND) + "hello")
             assert r.get_cursor_position() == (0, 0)


### PR DESCRIPTION
The test should never look inside of the `~/.mltype/config.ini`. The way it is done is via passing en empty config file via the 
`--config` command line option.

Closes #94 