### PR TITLE
Changed np.bool to np.bool_ as those have been depreciated.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, 3.10]
+        python-version: [3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on:  ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: [3.8, 3.9, '3.10']
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,4 +41,4 @@ jobs:
 
     - name: Test with pytest
       run: |
-        PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python pytest --color=yes  # see tox.ini for config
+        pytest --color=yes  # see tox.ini for config

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,4 +41,4 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest --color=yes  # see tox.ini for config
+        PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python pytest --color=yes  # see tox.ini for config

--- a/mltype/ml.py
+++ b/mltype/ml.py
@@ -136,7 +136,7 @@ def text2features(text, vocabulary):
 
     ch2ix = {ch: ix for ix, ch in enumerate(vocabulary)}
 
-    output = np.zeros((text_size, vocab_size), dtype=np.bool)
+    output = np.zeros((text_size, vocab_size), dtype=np.bool_)
     for i, ch in enumerate(text):
         try:
             output[i, ch2ix[ch]] = True
@@ -195,7 +195,7 @@ def sample_char(
     if previous_chars:
         features = text2features(previous_chars, vocabulary)
     else:
-        features = np.zeros((1, len(vocabulary)), dtype=np.bool)
+        features = np.zeros((1, len(vocabulary)), dtype=np.bool_)
 
     network.eval()
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
             "pytest-coverage",
             "tox",
         ],
-        "mlflow": ["mlflow<=1.10.0"],
+        "mlflow": ["mlflow"],
     },
     entry_points={
         "console_scripts": [

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -16,7 +16,6 @@ from mltype.interactive import TypedTextWriter, main_basic
 
 class TestTypedTextWriter:
     def test_colors(self, monkeypatch):
-
         expected_keys = {
             "color_default_background",
             "color_default_foreground",

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -275,7 +275,6 @@ class TestSingleCharacterLSTM:
         )
 
     def test_pl(self, monkeypatch, tmpdir):
-
         batch_size = 2
         window_size = 3
         vocab_size = 4

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -120,7 +120,7 @@ class TestText2Features:
         vocabulary = ["a", "b", "c"]
 
         res_true = np.array(
-            [[1, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 0]], dtype=np.bool
+            [[1, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 0]], dtype=np.bool_
         )
         res = text2features(text, vocabulary)
 


### PR DESCRIPTION
https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations
Note that there a difference between the two. `np.bool` was actually just an alias for the built-in `bool`, whereas `np.bool_` is a numpy scalar. The `np.bool_` is stored as a byte and is not a subclass of the [`int_`](https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.int_) type. Ref: https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.bool_